### PR TITLE
Move register/logn popup to center and add opacity to outside

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -106,8 +106,8 @@ const useStyles = makeStyles((theme) => ({
         },
     },
     popoverRegisterAndLogin: {
-        width: '100%',
-        backgroundColor: 'rgba(81,81,81,0.5',
+        width: '100vw',
+        backgroundColor: 'rgba(81,81,81,0.7)',
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
@@ -228,7 +228,7 @@ function Navbar() {
                     vertical: 'top',
                     horizontal: 'right',
                 }}
-                style={{}}
+                className={classes.popoverRegisterAndLogin}
             >
                 <RegisterAndLogin />
             </Popover>


### PR DESCRIPTION
Move the popup to center of screen, and add opacity to outside of box.

Add a little custom css to popover tag.

Now, the popup is shown in center, and the outside is transparent.